### PR TITLE
Add reference to Git::Hooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,7 @@
 					<li>Blog Post: <a href="http://omerkatz.com/git-hooks-part-i-the-basics">Git Hooks (Part I): The Basics</a></li>
 					<li>Blog Post: <a href="http://codeinthehole.com/writing/tips-for-using-a-Git-pre-commit-hook/">Tips for using Git pre commit hook</a></li>
 					<li>Code: <a href="https://github.com/icefox/git-hooks">Git Hooks Manager</a> - A tool to manage project, user, and global Git hooks for multiple Git repositories.</li>
+					<li>Code: <a href="https://github.com/gnustavo/Git-Hooks">Git::Hooks</a> - A framework for implementing Git (and Gerrit) hooks.</li>
 				</ul>
 				
 				<hr class="soften">


### PR DESCRIPTION
Hello Matthew.

I hope this is the proper way to suggest an addition to your githooks.com site. If not, please, let me know how do you prefer to get it.

I'm suggesting a link to a project of mine, called [Git::Hooks](https://github.com/gnustavo/Git-Hooks). It's a framework for simplifying the implementation and usage of Git hooks.

I hope it's not too much self-serving of my part. :-)

BTW, it seems that your site (githooks.com) isn't uptodate with regards to the contents of the gh-pages branch.

Regards.
## 

Gustavo.
