### PR TITLE
Add some links back to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,22 +135,23 @@
 				
 				<p>Here's a full list of hooks you can attach scripts to:</p>
 				<ul>
-					<li>applypatch-msg</li>
-					<li>pre-applypatch</li>
-					<li>post-applypatch</li>
-					<li>pre-commit</li>
-					<li>prepare-commit-msg</li>
-					<li>commit-msg</li>
-					<li>post-commit</li>
-					<li>pre-rebase</li>
-					<li>post-checkout</li>
-					<li>post-merge</li>
-					<li>pre-receive</li>
-					<li>update</li>
-					<li>post-receive</li>
-					<li>post-update</li>
-					<li>pre-auto-gc</li>
-					<li>post-rewrite</li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--applypatch-msg.sample">applypatch-msg</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--pre-applypatch.sample">pre-applypatch</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L63">post-applypatch</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--pre-commit.sample">pre-commit</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--prepare-commit-msg.sample">prepare-commit-msg</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--commit-msg.sample">commit-msg</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L131">post-commit</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--pre-rebase.sample">pre-rebase</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L149">post-checkout</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L167">post-merge</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L211">pre-receive</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--update.sample">update</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L283">post-receive</a></li>
+					<li><a href="https://github.com/git/git/blob/master/templates/hooks--post-update.sample">post-update</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L344">pre-auto-gc</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L351">post-rewrite</a></li>
+					<li><a href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L181">pre-push</a></li>
 				</ul>
 
 				<hr class="soften">


### PR DESCRIPTION
I prefer to link to the templates but templates for all of the hooks are not available, in that case link to the right part of the githooks.txt file.  Be careful as these line numbers change these links won't work.
