### PR TITLE
Include GitPHPHooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
 					<li><a href="https://pypi.python.org/pypi/git-pre-commit-hook">git-pre-commit-hook</a> - Hook that blocks bad commits. Useful for Python-development.</li>
 					<li><a href="https://metacpan.org/pod/App::GitHooks">App::GitHooks</a> - A modular and easy to configure git hooks framework, supporting <a href="https://metacpan.org/search?q=App%3A%3AGitHooks%3A%3APlugin%3A%3A">many plugins</a>.</li>
 					<li><a href="https://pythonhosted.org/jig/">Jig</a> - A pre-commit hook on steroids</li>
+					<li><a href="https://github.com/wecodemore/GitPHPHooks">GitPHPHooks</a> - Write your hooks in PHP, manage and organize them on a task and project level. Has an additional Hooks library <a href="https://github.com/wecodemore/GitPHPHooksLibrary">on GitHub</a></li>
 				</ul>
 				<hr class="soften">
 				<h2>Contribute</h2>


### PR DESCRIPTION
Add a link to GitPHPHooks and the library to the "projects" section. The project is available via GitHub and Packagist.
