### PR TITLE
Add rycus86/githooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
           <li><a href="https://github.com/BernardoSilva/git-hooks-php">git-hooks-php</a> - Git hooks for PHP based projects.</li>
           <li><a href="https://github.com/elpete/commandbox-githooks">commandbox-githooks</a> - Git hooks for CommandBox CFML based projects.</li>
           <li><a href="https://github.com/nkantar/Autohook">Autohook</a> - A very, <em>very</em> small Git hook manager with focus on automation.</li>
+          <li><a href="https://github.com/rycus86/githooks">Githooks</a> - Auto-install Git hook, that supports hooks in any language checked into Git and also shared repos.</li>
         </ul>
         <hr class="soften">
         <h2>Contribute</h2>


### PR DESCRIPTION
Hi,

I'd like to add my project to the list on your website.
The GitHub project link is: https://github.com/rycus86/githooks
There's also a blog post on it: https://blog.viktoradam.net/2018/07/26/githooks-auto-install-hooks/

Thanks!