### PR TITLE
Adds `id` attributes to all `h2` elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
     <div class="container">
       <div id="body" class="row">
         <div class="span16">
-          <h2>What are Git hooks?</h2>
+          <h2 id="what-are-git-hooks">What are Git hooks?</h2>
           <p>
             Git hooks are scripts that Git executes before or after events such
             as: <b>commit</b>, <b>push</b>, and <b>receive</b>. Git hooks are a
@@ -156,7 +156,7 @@
           </ul>
 
           <hr class="soften" />
-          <h2>How do git hooks work?</h2>
+          <h2 id="how-do-git-hooks-work">How do git hooks work?</h2>
           <p>
             Every Git repository has a <code>.git/hooks</code> folder with a
             script for each hook you can bind to. You're free to change or
@@ -271,7 +271,7 @@
           </ul>
 
           <hr class="soften" />
-          <h2>Why should I care?</h2>
+          <h2 id="why-should-i-care">Why should I care?</h2>
           <p>
             Fair question! Git hooks can greatly increase your productivity as a
             developer. For example, being able to push to your staging or
@@ -282,14 +282,14 @@
           </p>
 
           <hr class="soften" />
-          <h2>How do I implement Git hooks?</h2>
+          <h2 id="how-do-i-implement-git-hooks">How do I implement Git hooks?</h2>
           <p>
             The short and easy: Overwrite (or create) one of the scripts in
             <code>.git/hooks</code> and make it executable.
           </p>
 
           <hr class="soften" />
-          <h2>Reading</h2>
+          <h2 id="reading">Reading</h2>
           <ul>
             <li>
               <a
@@ -329,7 +329,7 @@
           </ul>
 
           <hr class="soften" />
-          <h2>Projects</h2>
+          <h2 id="projects">Projects</h2>
           <ul>
             <li>
               <a href="https://github.com/brigade/overcommit">overcommit</a> - A
@@ -460,7 +460,7 @@
           </ul>
 
           <hr class="soften" />
-          <h2>Snippets</h2>
+          <h2 id="snippets">Snippets</h2>
           <ul>
             <li>
               <a href="https://gist.github.com/kalpeshsingh/e7682478b8927700c714f12e37f0837e">Prevent Direct Push to Master</a>
@@ -469,7 +469,7 @@
           </ul>
 
           <hr class="soften" />
-          <h2>Contribute</h2>
+          <h2 id="contribute">Contribute</h2>
           <p>
             If you have a Git hook you love, or a resource you've written for
             the community - please create a pull request
@@ -477,7 +477,7 @@
           </p>
 
           <hr class="soften" />
-          <h2>Maintainer</h2>
+          <h2 id="maintainer">Maintainer</h2>
           <p>
             Howdy, my name is
             <a href="https://thematthewhudson.com/">Matthew Hudson</a> and I


### PR DESCRIPTION
I wanted to send someone a link to the list of projects, but there wasn't a way to link to just that section of the page, because there are no `id` attributes for the `h2` elements. Adding these will make it easier to link to specific sections. This could also help with adding a table of contents to the top of the page in the future.