### PR TITLE
Replace links to generated documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L74"
+                href="https://www.git-scm.com/docs/githooks#_post_applypatch"
                 >post-applypatch</a
               >
             </li>
@@ -204,7 +204,7 @@
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L142"
+                href="https://www.git-scm.com/docs/githooks#_post_commit"
                 >post-commit</a
               >
             </li>
@@ -216,19 +216,19 @@
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L160"
+                href="https://www.git-scm.com/docs/githooks#_post_checkout"
                 >post-checkout</a
               >
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L178"
+                href="https://www.git-scm.com/docs/githooks#_post_merge"
                 >post-merge</a
               >
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L221"
+                href="https://www.git-scm.com/docs/githooks#pre-receive"
                 >pre-receive</a
               >
             </li>
@@ -240,7 +240,7 @@
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L295"
+                href="https://www.git-scm.com/docs/githooks#post-receive"
                 >post-receive</a
               >
             </li>
@@ -252,19 +252,19 @@
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L387"
+                href="https://www.git-scm.com/docs/githooks#_pre_auto_gc"
                 >pre-auto-gc</a
               >
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L394"
+                href="https://www.git-scm.com/docs/githooks#_post_rewrite"
                 >post-rewrite</a
               >
             </li>
             <li>
               <a
-                href="https://github.com/git/git/blob/master/Documentation/githooks.txt#L192"
+                href="https://www.git-scm.com/docs/githooks#_pre_push"
                 >pre-push</a
               >
             </li>


### PR DESCRIPTION
The link to the documentation source was mostly not the correct line anymore.
Fixes #39 