### PR TITLE
Add Git Build Hook Maven Plugin and remove dead link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@
               command line git hook management tool.
             </li>
             <li>
-              <a href="https://github.com/rudikershaw/git-build-hooks">Git Build Hook Maven Plugin</a> 
+              <a href="https://github.com/rudikershaw/git-build-hook">Git Build Hook Maven Plugin</a> 
               - A maven plugin for managing client side (local) git configuration and installing hooks for those working on your project.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -433,11 +433,8 @@
               command line git hook management tool.
             </li>
             <li>
-              <a href="https://github.com/icefox/git-hooks"
-                >Git Hooks Manager</a
-              >
-              - A tool to manage project, user, and global Git hooks for
-              multiple Git repositories.
+              <a href="https://github.com/rudikershaw/git-build-hooks">Git Build Hook Maven Plugin</a> 
+              - A maven plugin for managing client side (local) git configuration and installing hooks for those working on your project.
             </li>
             <li>
               <a href="https://github.com/gnustavo/Git-Hooks">Git::Hooks</a> - A


### PR DESCRIPTION
I didn't know what kind of ordering you are preferring to the list of projects, so I added this one in the same place as something I removed (there was a dead link to the project).