### PR TITLE
Add blog post on using direnv to manage git hooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,6 +406,11 @@
                 PowerShell and with IntelliJ</a
               >
             </li>
+            <li>
+              <a href="https://knpw.rs/blog/direnv-git-hooks"
+                >Using direnv to Automatically Manage Git Hooks</a
+              >
+            </li>
           </ul>
 
           <hr class="soften" />


### PR DESCRIPTION
I wrote a blog post back in November documenting my now-favorite method of managing git hooks, as well as an alternative using `make`. The post is also linked from https://github.com/CompSciLauren/awesome-git-hooks