### PR TITLE
fix(docs): add missing `p` to `git-precommit-check`

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,7 +575,7 @@
               - Commitlint helps your team adhere to a commit convention.
             </li>
             <li>
-              <a href="https://mbrehin.github.io/git-precommit-checks/">git-recommit-checks</a>
+              <a href="https://mbrehin.github.io/git-precommit-checks/">git-precommit-checks</a>
               - Configurable checks for staged contents.
             </li>
             <li>


### PR DESCRIPTION
Hi Matthew,

Thank you for the merge 🙂
After reviewing the website I saw a typo.
 