### PR TITLE
Update lefthook URL and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,8 +567,8 @@
               ".githooks/" directory.
             </li>
             <li>
-              <a href="https://github.com/Arkweid/lefthook">Lefthook</a> - The
-              fastest polyglot Git hooks manager.
+              <a href="https://github.com/evilmartians/lefthook">Lefthook</a> -
+              Fast and powerful Git hooks manager for any type of projects.
             </li>
             <li>
               <a href="https://github.com/fisker/git-hooks-list"


### PR DESCRIPTION
This updates [lefthook](https://github.com/evilmartians/lefthook) to use the latest URL and repository description