### PR TITLE
Remove archived gjira

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,11 +585,6 @@
               tasks as declarative configuration inside your repo!
             </li>
             <li>
-              <a href="https://github.com/benmezger/gjira">GJira</a>
-              - Automatically add Jira task ID and story ID to the body of the
-              commit message.
-            </li>
-            <li>
               <a href="https://commitlint.js.org/">Commit lint</a>
               - Commitlint helps your team adhere to a commit convention.
             </li>


### PR DESCRIPTION
This removes the entry for [gjira](https://github.com/benmezger/gjira), which has been archived and not been receiving updates for 3+ years.